### PR TITLE
Allow setting signature version to S3 uploader

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -282,6 +282,18 @@ Links are generated as presigned urls for security
    EXPLORER_S3_LINK_EXPIRATION = 3600
 
 
+S3 signature version
+********************
+
+The signature version when signing requests.
+As of ``boto3`` version 1.13.21 the default signature version used for generating presigned urls is still ``v2``.
+To be able to access your s3 objects in all regions through presigned urls, explicitly set this to ``s3v4``.
+
+.. code-block:: python
+
+   EXPLORER_S3_SIGNATURE_VERSION = 's3v4'
+
+
 From email
 **********
 

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -133,6 +133,7 @@ FROM_EMAIL = getattr(
 S3_REGION = getattr(settings, "EXPLORER_S3_REGION", "us-east-1")
 S3_ENDPOINT_URL = getattr(settings, "EXPLORER_S3_ENDPOINT_URL", None)
 S3_DESTINATION = getattr(settings, "EXPLORER_S3_DESTINATION", '')
+S3_SIGNATURE_VERSION = getattr(settings, "EXPLORER_S3_SIGNATURE_VERSION", 's2')
 
 UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -133,7 +133,7 @@ FROM_EMAIL = getattr(
 S3_REGION = getattr(settings, "EXPLORER_S3_REGION", "us-east-1")
 S3_ENDPOINT_URL = getattr(settings, "EXPLORER_S3_ENDPOINT_URL", None)
 S3_DESTINATION = getattr(settings, "EXPLORER_S3_DESTINATION", '')
-S3_SIGNATURE_VERSION = getattr(settings, "EXPLORER_S3_SIGNATURE_VERSION", 's2')
+S3_SIGNATURE_VERSION = getattr(settings, "EXPLORER_S3_SIGNATURE_VERSION", 'v2')
 
 UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 

--- a/explorer/utils.py
+++ b/explorer/utils.py
@@ -193,10 +193,14 @@ def get_valid_connection(alias=None):
 
 def get_s3_bucket():
     import boto3
+    from botocore.client import Config
     kwargs = {
         'aws_access_key_id': app_settings.S3_ACCESS_KEY,
         'aws_secret_access_key': app_settings.S3_SECRET_KEY,
-        'region_name': app_settings.S3_REGION
+        'region_name': app_settings.S3_REGION,
+        'config': Config(
+            signature_version=app_settings.S3_SIGNATURE_VERSION
+        )
     }
     if app_settings.S3_ENDPOINT_URL:
         kwargs['endpoint_url'] = app_settings.S3_ENDPOINT_URL


### PR DESCRIPTION
Hi all, this is my first contribution to the repo, please let me know if I missed something.

I'm adding a new S3 setting to allow the generation of pre-signed URLs using the `s3v4` signature. Depending on the S3 bucket configuration this may prevent this kind of message while trying to download a report from S3

```xml
<Error>
  <Code>InvalidArgument</Code>
  <Message>Requests specifying Server Side Encryption with AWS KMS managed keys require AWS Signature Version 4. 
  </Message>
    <ArgumentName>Authorization</ArgumentName>
    <ArgumentValue>null</ArgumentValue>
    <RequestId>ZYBB518E58AHT5M5</RequestId>
    <HostId>PjwIdjN554jKPDGy7pcLK5kSKPBkx0EtXRAfBIxjAhqaufE+ZqYu4c/GGLGP+ErZUgPYkCepDGA=</HostId>
</Error>
```

I kept the default value as `v2` to prevent backward compatibility issues.