### PR TITLE
updating repo name and readme tweaks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,4 +23,4 @@ The following people have contributed to django-sql-explorer:
 - Moe Elias
 
 
-A full list of contributors can be found on Github; https://github.com/groveco/django-sql-explorer/graphs/contributors
+A full list of contributors can be found on Github; https://github.com/chrisclark/django-sql-explorer/graphs/contributors

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,7 @@
 Change Log
 ==========
 
-This document records all notable changes to `django-sql-explorer <https://github.com/groveco/django-sql-explorer>`_.
+This document records all notable changes to `django-sql-explorer <https://github.com/chrisclark/django-sql-explorer>`_.
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
 `unreleased`_ changes

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,8 @@
 SQL Explorer
 ============
 
+`Documentation <https://django-sql-explorer.readthedocs.io/en/latest/>`_
+
 SQL Explorer aims to make the flow of data between people fast,
 simple, and confusion-free. It is a Django-based application that you
 can add to an existing Django site, or use as a standalone business
@@ -36,14 +38,7 @@ SQL Explorer values simplicity, intuitive use, unobtrusiveness,
 stability, and the principle of least surprise.
 
 SQL Explorer is inspired by any number of great query and
-reporting tools out there.
-
-The original idea came from Stack Exchange's `Data Explorer
-<http://data.stackexchange.com/stackoverflow/queries>`_, but also owes
-credit to similar projects like `Redash <http://redash.io/>`_ and
-`Blazer <https://github.com/ankane/blazer>`_.
-
-You can read the full documentation `here <https://django-sql-explorer.readthedocs.io/en/latest/>`_
+reporting tools out there. See inspirations and others, below.
 
 Sql Explorer is MIT licensed, and pull requests are welcome.
 
@@ -64,11 +59,9 @@ Sql Explorer is MIT licensed, and pull requests are welcome.
 .. image:: https://s3-us-west-1.amazonaws.com/django-sql-explorer/2019_snapshots.png
 
 
-Alternatives
+Inspirations & Similar Projects
 ------------
 
-* `django-sql-dashboard`_: provides an authenticated interface for executing read-only SQL queries directly against your PostgreSQL database, bringing a useful subset of `Datasette`_ to Django.
-
-
-.. _django-sql-dashboard: https://github.com/simonw/django-sql-dashboard
-.. _Datasette : https://datasette.io/
+* `django-sql-dashboard <https://github.com/simonw/django-sql-dashboard>`_
+* Stack Exchange's `Data Explorer <http://data.stackexchange.com/stackoverflow/queries>`_
+* `Blazer <https://github.com/ankane/blazer>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath('.'))
 current_year = datetime.datetime.now().year
 project = 'Django SQL Explorer'
 copyright = f'2016-{current_year}, Chris Clark'
-author = 'Grove Co'
+author = 'Chris Clark'
 
 version = explorer.get_version(True)
 # The full version, including alpha/beta/rc tags.

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -73,8 +73,7 @@
             <div class="row">
                 <div class="col-md-12 text-center">
                     <p class="text-muted">
-                        Powered by <a href="https://www.github.com/groveco/django-sql-explorer/">django-sql-explorer</a> from
-                        <a href="https://www.grove.co">Grove Collaborative</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
+                        Powered by <a href="https://www.github.com/chrisclark/django-sql-explorer/">django-sql-explorer</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
                     </p>
                 </div>
             </div>

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,11 @@ setup(
                  " view, and export the results."),
     license="MIT",
     keywords="django sql explorer reports reporting csv database query",
-    url="https://github.com/groveco/django-sql-explorer",
+    url="https://github.com/chrisclark/django-sql-explorer",
     project_urls={
       'Changes': 'https://django-sql-explorer.readthedocs.io/en/latest/history.html',
       'Documentation': 'https://django-sql-explorer.readthedocs.io/en/latest/',
-      'Issues': 'https://github.com/groveco/django-sql-explorer/issues'
+      'Issues': 'https://github.com/chrisclark/django-sql-explorer/issues'
     },
     packages=['explorer'],
     long_description=long_description,


### PR DESCRIPTION
No longer under Grove purview. Organized links in readme. Moved documentation to the top.