### PR TITLE
Checking if the settings.AUTH_USER_MODEL has email field or not!

### DIFF
--- a/explorer/forms.py
+++ b/explorer/forms.py
@@ -29,7 +29,6 @@ class SqlField(CharField):
 
 
 class QueryForm(ModelForm):
-
     sql = SqlField()
     snapshot = BooleanField(widget=CheckboxInput, required=False)
     connection = CharField(widget=Select, required=False)
@@ -49,8 +48,14 @@ class QueryForm(ModelForm):
 
     @property
     def created_by_user_email(self):
-        return self.instance.created_by_user.email if \
-            self.instance.created_by_user else "--"
+        user = self.instance.created_by_user
+        if user:
+            try:
+                return user.email
+            except AttributeError:
+                pass
+
+        return "--"
 
     @property
     def created_at_time(self):


### PR DESCRIPTION
If `settings.AUTH_USER_MODEL` is a custom user model that does not have an email field, the `created_by_user_email` function throws an AttributeError exception.