### PR TITLE
Anonymous usage data collection (issue #595)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ explorer/static/
 # Sphinx documentation
 docs/_build/
 .env
+tst

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ SQL Explorer
 
 `Documentation <https://django-sql-explorer.readthedocs.io/en/latest/>`_
 
+`Official Website <https://www.sqlexplorer.io/>`_
+
 SQL Explorer aims to make the flow of data between people fast,
 simple, and confusion-free. It is a Django-based application that you
 can add to an existing Django site, or use as a standalone business

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ furo
 Sphinx>4
 sphinx-copybutton
 sphinxext-opengraph
+requests>=2.3

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -2,7 +2,6 @@ from pydoc import locate
 
 from django.conf import settings
 
-
 EXPLORER_CONNECTIONS = getattr(settings, "EXPLORER_CONNECTIONS", {})
 EXPLORER_DEFAULT_CONNECTION = getattr(
     settings, "EXPLORER_DEFAULT_CONNECTION", None
@@ -36,7 +35,6 @@ EXPLORER_SQL_BLACKLIST = getattr(
         "REVOKE",
     )
 )
-
 
 EXPLORER_DEFAULT_ROWS = getattr(settings, "EXPLORER_DEFAULT_ROWS", 1000)
 
@@ -104,7 +102,7 @@ EXPLORER_GET_USER_QUERY_VIEWS = lambda: getattr(  # noqa
 EXPLORER_TOKEN_AUTH_ENABLED = lambda: getattr(  # noqa
     settings, "EXPLORER_TOKEN_AUTH_ENABLED", False
 )
-EXPLORER_NO_PERMISSION_VIEW = lambda: locate(# noqa
+EXPLORER_NO_PERMISSION_VIEW = lambda: locate(  # noqa
     getattr(
         settings,
         "EXPLORER_NO_PERMISSION_VIEW",
@@ -132,6 +130,11 @@ UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 EXPLORER_CHARTS_ENABLED = getattr(settings, "EXPLORER_CHARTS_ENABLED", False)
 
 EXPLORER_SHOW_SQL_BY_DEFAULT = getattr(settings, "EXPLORER_SHOW_SQL_BY_DEFAULT", True)
+
+EXPLORER_ENABLE_ANONYMOUS_STATS = getattr(settings, "EXPLORER_ENABLE_ANONYMOUS_STATS", True)
+EXPLORER_COLLECT_ENDPOINT_URL = lambda: getattr(  # noqa
+    settings, "EXPLORER_COLLECT_ENDPOINT_URL", "https://collect.sqlexplorer.io/stat"
+)
 
 # If set to True will autorun queries when viewed which is the historical behavior
 # Default to True if not set in order to be backwards compatible

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -2,6 +2,7 @@ from pydoc import locate
 
 from django.conf import settings
 
+
 EXPLORER_CONNECTIONS = getattr(settings, "EXPLORER_CONNECTIONS", {})
 EXPLORER_DEFAULT_CONNECTION = getattr(
     settings, "EXPLORER_DEFAULT_CONNECTION", None
@@ -35,6 +36,7 @@ EXPLORER_SQL_BLACKLIST = getattr(
         "REVOKE",
     )
 )
+
 
 EXPLORER_DEFAULT_ROWS = getattr(settings, "EXPLORER_DEFAULT_ROWS", 1000)
 
@@ -132,9 +134,7 @@ EXPLORER_CHARTS_ENABLED = getattr(settings, "EXPLORER_CHARTS_ENABLED", False)
 EXPLORER_SHOW_SQL_BY_DEFAULT = getattr(settings, "EXPLORER_SHOW_SQL_BY_DEFAULT", True)
 
 EXPLORER_ENABLE_ANONYMOUS_STATS = getattr(settings, "EXPLORER_ENABLE_ANONYMOUS_STATS", True)
-EXPLORER_COLLECT_ENDPOINT_URL = lambda: getattr(  # noqa
-    settings, "EXPLORER_COLLECT_ENDPOINT_URL", "https://collect.sqlexplorer.io/stat"
-)
+EXPLORER_COLLECT_ENDPOINT_URL = "https://collect.sqlexplorer.io/stat"
 
 # If set to True will autorun queries when viewed which is the historical behavior
 # Default to True if not set in order to be backwards compatible

--- a/explorer/apps.py
+++ b/explorer/apps.py
@@ -12,14 +12,10 @@ class ExplorerAppConfig(AppConfig):
     default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
+        from explorer.schema import build_async_schemas
         _validate_connections()
-        queue_async_schemas()
+        build_async_schemas()
         track_summary_stats()
-
-
-def queue_async_schemas():
-    from explorer.schema import build_async_schemas
-    build_async_schemas()
 
 
 def _get_default():

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from explorer import app_settings
+from explorer.tracker import Stat, StatNames
 from explorer.utils import (
     extract_params, get_params_for_url, get_s3_bucket, get_valid_connection, passes_blacklist, s3_url,
     shared_dict_update, swap_params,
@@ -108,6 +109,8 @@ class Query(models.Model):
             raise e
         ql.duration = ret.duration
         ql.save()
+        Stat(StatNames.QUERY_RUN,
+             {'sql_len': len(ql.sql), 'duration': ql.duration}).track()
         return ret, ql
 
     def execute(self):

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -110,7 +110,7 @@ class Query(models.Model):
         ql.duration = ret.duration
         ql.save()
         Stat(StatNames.QUERY_RUN,
-             {'sql_len': len(ql.sql), 'duration': ql.duration}).track()
+             {"sql_len": len(ql.sql), "duration": ql.duration}).track()
         return ret, ql
 
     def execute(self):

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -72,7 +72,7 @@ npm run dev
     <div class="container">
         <footer class="py-3 my-4">
             <p class="text-center text-body-secondary border-top pt-3">
-                Powered by <a href="https://www.github.com/chrisclark/django-sql-explorer/">django-sql-explorer</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
+                Powered by <a href="https://www.sqlexplorer.io/">SQL Explorer</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
             </p>
         </footer>
     </div>

--- a/explorer/tests/settings.py
+++ b/explorer/tests/settings.py
@@ -1,0 +1,27 @@
+from test_project.settings import *  # noqa
+
+EXPLORER_ENABLE_ANONYMOUS_STATS = False
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst",
+        "TEST": {
+            "NAME": "tst"
+        }
+    },
+    "alt": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst2",
+        "TEST": {
+            "NAME": "tst2"
+        }
+    },
+    "not_registered": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst3",
+        "TEST": {
+            "NAME": "tst3"
+        }
+    }
+}

--- a/explorer/tests/test_tracker.py
+++ b/explorer/tests/test_tracker.py
@@ -14,5 +14,5 @@ class TestTracker(TestCase):
 
     def test_gather_summary_stats(self):
         res = gather_summary_stats()
-        self.assertEqual(res['total_query_count'], 0)
-        self.assertEqual(res['default_database'], 'sqlite')
+        self.assertEqual(res["total_query_count"], 0)
+        self.assertEqual(res["default_database"], "sqlite")

--- a/explorer/tests/test_tracker.py
+++ b/explorer/tests/test_tracker.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from explorer.tracker import instance_identifier, gather_summary_stats
+
+
+class TestTracker(TestCase):
+
+    def test_instance_identifier(self):
+        v = instance_identifier()
+
+        # The SHA-256 hash produces a fixed-length output of 256 bits.
+        # When represented as a hexadecimal string, each byte (8 bits) is
+        # represented by 2 hex chars. 256/8*2 = 64
+        self.assertEqual(len(v), 64)
+
+    def test_gather_summary_stats(self):
+        res = gather_summary_stats()
+        self.assertEqual(res['total_query_count'], 0)
+        self.assertEqual(res['default_database'], 'sqlite')

--- a/explorer/tracker.py
+++ b/explorer/tracker.py
@@ -1,0 +1,103 @@
+# Anonymous usage stats
+# Opt-out by setting EXPLORER_ENABLE_ANONYMOUS_STATS = False in settings
+
+from explorer import app_settings
+import time
+import requests
+import json
+import threading
+from enum import Enum, auto
+from django.core.cache import cache
+
+
+def _instance_identifier():
+    """
+    We need a way of identifying unique instances of explorer to track usage.
+    There isn't an established approach I'm aware of, so have come up with
+    this. We take the timestamp of the first applied migration, and hash it
+    with the secret key.
+    """
+
+    import hashlib
+    from django.db.migrations.recorder import MigrationRecorder
+    from django.conf import settings
+    migration = MigrationRecorder.Migration.objects.all().order_by('applied').first()
+    ts = migration.applied.timestamp()
+    ts_bytes = str(ts).encode('utf-8')
+    s_bytes = settings.SECRET_KEY.encode('utf-8')
+    hashed_value = hashlib.sha256(ts_bytes + s_bytes).hexdigest()
+
+    return hashed_value
+
+
+def instance_identifier():
+    key = "explorer_instance_identifier"
+    r = cache.get(key)
+    if not r:
+        r = _instance_identifier()
+        cache.set(key, r, 60 * 60 * 24)
+    return r
+
+
+class SelfNamedEnum(Enum):
+
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+
+class StatNames(SelfNamedEnum):
+
+    QUERY_RUN = auto()
+    STARTUP_STATS = auto()
+
+
+class Stat(object):
+
+    def __init__(self, name: StatNames, value):
+        self.instanceId = instance_identifier()
+        self.time = time.time()
+        self.value = value
+        self.name = name.value
+
+    def track(self):
+        if app_settings.EXPLORER_ENABLE_ANONYMOUS_STATS:
+            data = json.dumps(self.__dict__)
+
+            def _send():
+                requests.post(app_settings.EXPLORER_COLLECT_ENDPOINT_URL(),
+                              data=data,
+                              headers={'Content-Type': 'application/json'})
+
+            thread = threading.Thread(target=_send)
+            thread.start()
+
+
+def gather_summary_stats():
+    from explorer.models import Query, QueryLog
+    from django.db import connection
+    from django.db.models import Count
+    from django.db.migrations.recorder import MigrationRecorder
+    from django.conf import settings
+
+    ql_stats = QueryLog.objects.aggregate(
+        total_count=Count('*'),
+        unique_run_by_user_count=Count('run_by_user_id', distinct=True)
+    )
+
+    q_stats = Query.objects.aggregate(
+        total_count=Count('*'),
+        unique_connection_count=Count('connection', distinct=True)
+    )
+
+    return {
+        "total_log_count": ql_stats['total_count'],
+        "unique_run_by_user_count": ql_stats['unique_run_by_user_count'],
+        "total_query_count": q_stats['total_count'],
+        "unique_connection_count": q_stats['unique_connection_count'],
+        "default_database": connection.vendor,
+        "django_install_date":
+            MigrationRecorder.Migration.objects.all().order_by('applied').first().applied.timestamp(),
+        "debug": settings.DEBUG,
+        "tasks_enabled": app_settings.ENABLE_TASKS,
+    }

--- a/explorer/tracker.py
+++ b/explorer/tracker.py
@@ -54,7 +54,7 @@ class StatNames(SelfNamedEnum):
     STARTUP_STATS = auto()
 
 
-class Stat(object):
+class Stat:
 
     def __init__(self, name: StatNames, value):
         self.instanceId = instance_identifier()

--- a/explorer/tracker.py
+++ b/explorer/tracker.py
@@ -21,14 +21,16 @@ def _instance_identifier():
     import hashlib
     from django.db.migrations.recorder import MigrationRecorder
     from django.conf import settings
-    migration = MigrationRecorder.Migration.objects.all().order_by('applied').first()
-    ts = migration.applied.timestamp()
-    ts_bytes = str(ts).encode('utf-8')
-    s_bytes = settings.SECRET_KEY.encode('utf-8')
-    hashed_value = hashlib.sha256(ts_bytes + s_bytes).hexdigest()
+    try:
+        migration = MigrationRecorder.Migration.objects.all().order_by("applied").first()
+        ts = migration.applied.timestamp()
+        ts_bytes = str(ts).encode("utf-8")
+        s_bytes = settings.SECRET_KEY.encode("utf-8")
+        hashed_value = hashlib.sha256(ts_bytes + s_bytes).hexdigest()
 
-    return hashed_value
-
+        return hashed_value
+    except Exception as e:
+        return "unknown: %s" % e
 
 def instance_identifier():
     key = "explorer_instance_identifier"
@@ -67,7 +69,7 @@ class Stat(object):
             def _send():
                 requests.post(app_settings.EXPLORER_COLLECT_ENDPOINT_URL(),
                               data=data,
-                              headers={'Content-Type': 'application/json'})
+                              headers={"Content-Type": "application/json"})
 
             thread = threading.Thread(target=_send)
             thread.start()
@@ -81,23 +83,23 @@ def gather_summary_stats():
     from django.conf import settings
 
     ql_stats = QueryLog.objects.aggregate(
-        total_count=Count('*'),
-        unique_run_by_user_count=Count('run_by_user_id', distinct=True)
+        total_count=Count("*"),
+        unique_run_by_user_count=Count("run_by_user_id", distinct=True)
     )
 
     q_stats = Query.objects.aggregate(
-        total_count=Count('*'),
-        unique_connection_count=Count('connection', distinct=True)
+        total_count=Count("*"),
+        unique_connection_count=Count("connection", distinct=True)
     )
 
     return {
-        "total_log_count": ql_stats['total_count'],
-        "unique_run_by_user_count": ql_stats['unique_run_by_user_count'],
-        "total_query_count": q_stats['total_count'],
-        "unique_connection_count": q_stats['unique_connection_count'],
+        "total_log_count": ql_stats["total_count"],
+        "unique_run_by_user_count": ql_stats["unique_run_by_user_count"],
+        "total_query_count": q_stats["total_count"],
+        "unique_connection_count": q_stats["unique_connection_count"],
         "default_database": connection.vendor,
         "django_install_date":
-            MigrationRecorder.Migration.objects.all().order_by('applied').first().applied.timestamp(),
+            MigrationRecorder.Migration.objects.all().order_by("applied").first().applied.timestamp(),
         "debug": settings.DEBUG,
         "tasks_enabled": app_settings.ENABLE_TASKS,
     }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 sqlparse>=0.4.0
 coverage
 factory-boy>=3.1.0
+requests~=2.31.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     optional: -r requirements/optional.txt
 commands =
     {envpython} --version
-    {env:COMMAND:coverage} run manage.py test
+    {env:COMMAND:coverage} run manage.py test --noinput
 ignore_outcome =
     djmain: True
 ignore_errors =


### PR DESCRIPTION
Gathers a variety of usage metrics (largely at application start-up) and sends to a collection endpoint.

Some of the more interesting bits of this are:
- Generating a stable, but unique, ID per 'install'. See explorer.tracker._instance_identifier()
- Running stat collection at app start time. Strangely, Django doesn't have a good way to do this. See explorer.apps.track_summary_stats()
- The HTTP requests that are sent to the collection endpoint are 'fire and forget' via a thread.
- New app setting - EXPLORER_ENABLE_ANONYMOUS_STATS - that can be set to False to disable data collection
