### PR TITLE
Anonymous telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ explorer/static/
 # Sphinx documentation
 docs/_build/
 .env
+tst

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,12 @@ Change Log
 This document records all notable changes to `django-sql-explorer <https://github.com/chrisclark/django-sql-explorer>`_.
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-`4.0.0`_ (2024-02-06)
+`4.1.0`_ (TBD)
+===========================
+* Anonymous usage telemetry. Can be disabled by setting EXPLORER_ENABLE_ANONYMOUS_STATS to False
+* `#594`_: Eliminate <script> tags to prevent potential Content Security Policy issues
+
+`4.0.2`_ (2024-02-06)
 ===========================
 * Add support for Django 5.0. Drop support for Python < 3.10.
 * Basic code completion in the editor!

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,9 @@
 SQL Explorer
 ============
 
-`Documentation <https://django-sql-explorer.readthedocs.io/en/latest/>`_
+`Official Website <https://www.sqlexplorer.io/>`_
+
+`Full Documentation <https://django-sql-explorer.readthedocs.io/en/late st/>`_
 
 SQL Explorer aims to make the flow of data between people fast,
 simple, and confusion-free. It is a Django-based application that you

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -7,13 +7,15 @@ minimum.
 Python
 ------
 
-=========================================================== ======= ================
-Name                                                        Version License
-=========================================================== ======= ================
-`sqlparse <https://github.com/andialbrecht/sqlparse/>`_     0.4.0   BSD
-=========================================================== ======= ================
+============================================================ ======= ================
+Name                                                         Version License
+============================================================ ======= ================
+`sqlparse <https://github.com/andialbrecht/sqlparse/>`_      0.4.0   BSD
+`requests <https://requests.readthedocs.io/en/latest/>`_     2.2.0   Apache 2.0
+============================================================ ======= ================
 
 - sqlparse is used for SQL formatting
+- requests is used for anonymous usage tracking
 
 **Python - Optional Dependencies**
 
@@ -42,30 +44,3 @@ The bundle for the SQL editor is fairly large at ~400kb, due primarily to CodeMi
 
 The built front-end files are distributed in the PyPi release (and will be found by collectstatic). Instructions for building the front-end files are in :doc:`install`.
 
-Tests
------
-
-Factory Boy is needed if you'd like to run the tests, which can you do
-easily:
-
-``python manage.py test``
-
-and with coverage:
-
-``coverage run --source='.' manage.py test``
-
-then:
-
-``coverage report``
-
-...97%! Huzzah!
-
-Running Locally
----------------
-
-Included is a test_project that you can use to kick the tires. Just
-create a new virtualenv, cd into ``test_project`` and run ``start.sh`` (or
-walk through the steps yourself) to get a test instance of the app up
-and running.
-
-You can now navigate to 127.0.0.1:8000/ and begin exploring!

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,63 @@
+Running Locally (quick start)
+-----------------------------
+
+Included is a test_project that you can use to kick the tires. Just
+create a new virtualenv, cd into ``test_project`` and run ``start.sh`` (or
+walk through the steps yourself) to get a test instance of the app up
+and running.
+
+You can now navigate to 127.0.0.1:8000/ and begin exploring!
+
+Installing From Source
+----------------------
+
+If you are installing SQL Explorer from source (by cloning the repository),
+you may want to first look at simply running test_project/start.sh.
+
+If you want to install into an existing project, you can do so by following
+the install instructions, and then additionally building the front-end dependencies.
+
+After cloning, simply run:
+
+::
+
+    nvm install
+    nvm use
+    npm install
+    npm run build
+
+The front-end assets will be built and placed in the /static/ folder
+and collected properly by your Django installation during the `collect static`
+phase. Copy the /explorer directory into site-packages and you're ready to go.
+
+Tests
+-----
+
+Factory Boy is needed if you'd like to run the tests, which can you do
+easily:
+
+``python manage.py test --settings=tests.settings``
+
+and with coverage:
+
+``coverage run --source='.' manage.py test --settings=tests.settings``
+``coverage combine``
+``coverage report``
+
+Running Celery
+--------------
+
+To run tests with Celery enabled, you will need to install Redis and Celery.
+::
+
+    brew install redis
+    pip install celery
+    pip install redis
+
+Then run the redis server and the celery worker. A good way of doing it is:
+::
+
+    screen -d -S 'redis' -m redis-server
+    screen -d -S 'celery' -m celery -A test_project worker
+
+Finally, set ``EXPLORER_TASKS_ENABLED`` to True in tests.settings and run the tests.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Django SQL Explorer
 
    features.rst
    install.rst
+   development.rst
    settings.rst
    dependencies.rst
    history.rst

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -102,29 +102,10 @@ settings.py to enable these features.
 Installing From Source
 ----------------------
 
-If you are installing SQL Explorer from source (by cloning the repository),
-you may want to first look at simply running test_project/start.sh.
-
-If you want to install it into an existing project, you can do so by following
-the instructions above, and additionally building the front-end dependencies.
-
-After cloning, simply run:
-
-::
-
-    nvm install
-    nvm use
-    npm install
-    npm run build
-
-The front-end assets will be built and placed in the /static/ folder
-and collected properly by your Django installation during the `collect static`
-phase. Copy the /explorer directory into site-packages and you're ready to go.
-
-And frankly, as long as you have a reasonably modern version of Node and NPM
-installed, you can probably skip the nvm steps.
-
 Because the front-end assets must be built, installing SQL Explorer via pip
 from github is not supported. The package will be installed, but the front-end
 assets will be missing and will not be able to be built, as the necessary
 configuration files are not included when github builds the wheel for pip.
+
+To run from source, clone the repository and follow the :doc:`development`
+instructions.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -319,7 +319,7 @@ The export buttons to use. Default includes Excel, so xlsxwriter from ``requirem
 
 
 Unsafe rendering
-*****************************
+****************
 
 Disable auto escaping for rendering values from the database. Be wary of XSS attacks if querying unknown data.
 
@@ -337,3 +337,13 @@ but a dotted path to a python view can be used
 .. code-block:: python
 
    EXPLORER_NO_PERMISSION_VIEW = 'explorer.views.auth.safe_login_view_wrapper'
+
+Anonymous Usage Stat Collection
+*******************************
+
+By default, anonymous usage statistics are collected. To disable this, set the following setting to False.
+You can see what is being collected in tracker.py.
+
+.. code-block:: python
+
+    EXPLORER_ENABLE_ANONYMOUS_STATS = False

--- a/explorer/app_settings.py
+++ b/explorer/app_settings.py
@@ -104,7 +104,7 @@ EXPLORER_GET_USER_QUERY_VIEWS = lambda: getattr(  # noqa
 EXPLORER_TOKEN_AUTH_ENABLED = lambda: getattr(  # noqa
     settings, "EXPLORER_TOKEN_AUTH_ENABLED", False
 )
-EXPLORER_NO_PERMISSION_VIEW = lambda: locate(# noqa
+EXPLORER_NO_PERMISSION_VIEW = lambda: locate(  # noqa
     getattr(
         settings,
         "EXPLORER_NO_PERMISSION_VIEW",
@@ -132,6 +132,9 @@ UNSAFE_RENDERING = getattr(settings, "EXPLORER_UNSAFE_RENDERING", False)
 EXPLORER_CHARTS_ENABLED = getattr(settings, "EXPLORER_CHARTS_ENABLED", False)
 
 EXPLORER_SHOW_SQL_BY_DEFAULT = getattr(settings, "EXPLORER_SHOW_SQL_BY_DEFAULT", True)
+
+EXPLORER_ENABLE_ANONYMOUS_STATS = getattr(settings, "EXPLORER_ENABLE_ANONYMOUS_STATS", True)
+EXPLORER_COLLECT_ENDPOINT_URL = "https://collect.sqlexplorer.io/stat"
 
 # If set to True will autorun queries when viewed which is the historical behavior
 # Default to True if not set in order to be backwards compatible

--- a/explorer/apps.py
+++ b/explorer/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
 from django.db import connections as djcs
+from django.db.utils import OperationalError
 from django.utils.translation import gettext_lazy as _
 
 
@@ -14,6 +15,7 @@ class ExplorerAppConfig(AppConfig):
         from explorer.schema import build_async_schemas
         _validate_connections()
         build_async_schemas()
+        track_summary_stats()
 
 
 def _get_default():
@@ -42,3 +44,25 @@ def _validate_connections():
                 f"EXPLORER_CONNECTIONS contains ({name}, {conn_name}), "
                 f"but {conn_name} is not a valid Django DB connection."
             )
+
+
+def track_summary_stats():
+    from explorer.tracker import Stat, StatNames
+    from explorer.tracker import gather_summary_stats
+    from explorer.models import Query
+
+    # Django doesn't actually have a way of running code on application initialization, so we have come up with this.
+    # The app.ready() method (the call site for this function) is invoked *before* any migrations are run. So if were
+    # to just call this function in ready(), without the try: block, then it would always fail the very first time
+    # Django runs (and e.g. in test runs) because no tables have yet been created. The intuitive way to handle this with
+    # Django would be to tie into the post_migrate signal in ready() and run this function on post_migrate. But that
+    # doesn't work because that signal is only called if indeed a migrations has been applied. If the app restarts and
+    # there are no new migrations, the signal never fires. So instead we check if the Query table exists, and if it
+    # does, we're good to gather stats.
+    try:
+        Query.objects.first()
+    except OperationalError:
+        return
+    else:
+        payload = gather_summary_stats()
+        Stat(StatNames.STARTUP_STATS, payload).track()

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from explorer import app_settings
+from explorer.tracker import Stat, StatNames
 from explorer.utils import (
     extract_params, get_params_for_url, get_s3_bucket, get_valid_connection, passes_blacklist, s3_url,
     shared_dict_update, swap_params,
@@ -108,6 +109,8 @@ class Query(models.Model):
             raise e
         ql.duration = ret.duration
         ql.save()
+        Stat(StatNames.QUERY_RUN,
+             {"sql_len": len(ql.sql), "duration": ql.duration}).track()
         return ret, ql
 
     def execute(self):

--- a/explorer/templates/explorer/base.html
+++ b/explorer/templates/explorer/base.html
@@ -72,7 +72,7 @@ npm run dev
     <div class="container">
         <footer class="py-3 my-4">
             <p class="text-center text-body-secondary border-top pt-3">
-                Powered by <a href="https://www.github.com/chrisclark/django-sql-explorer/">django-sql-explorer</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
+                Powered by <a href="https://www.sqlexplorer.io/">SQL Explorer</a>. Rendered at {% now "SHORT_DATETIME_FORMAT" %}
             </p>
         </footer>
     </div>

--- a/explorer/tests/settings.py
+++ b/explorer/tests/settings.py
@@ -1,0 +1,30 @@
+from test_project.settings import *  # noqa
+
+EXPLORER_ENABLE_ANONYMOUS_STATS = False
+EXPLORER_TASKS_ENABLED = False  # set to true to test async tasks
+CELERY_BROKER_URL = "redis://localhost:6379/0"
+CELERY_TASK_ALWAYS_EAGER = True
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst",
+        "TEST": {
+            "NAME": "tst"
+        }
+    },
+    "alt": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst2",
+        "TEST": {
+            "NAME": "tst2"
+        }
+    },
+    "not_registered": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": "tst3",
+        "TEST": {
+            "NAME": "tst3"
+        }
+    }
+}

--- a/explorer/tests/test_tasks.py
+++ b/explorer/tests/test_tasks.py
@@ -85,7 +85,7 @@ class TestTasks(TestCase):
     @unittest.skipIf(not app_settings.ENABLE_TASKS, "tasks not enabled")
     @patch("explorer.schema.build_schema_info")
     def test_build_schema_cache_async(self, mocked_build):
-        mocked_build.return_value = ["list_of_tuples"]
+        mocked_build.return_value = [("table", [("column", "Integer")]),]
         schema = build_schema_cache_async(CONN)
         assert mocked_build.called
-        self.assertEqual(schema, ["list_of_tuples"])
+        self.assertEqual(schema, [("table", [("column", "Integer")]),])

--- a/explorer/tests/test_tracker.py
+++ b/explorer/tests/test_tracker.py
@@ -1,0 +1,18 @@
+from django.test import TestCase
+from explorer.tracker import instance_identifier, gather_summary_stats
+
+
+class TestTracker(TestCase):
+
+    def test_instance_identifier(self):
+        v = instance_identifier()
+
+        # The SHA-256 hash produces a fixed-length output of 256 bits.
+        # When represented as a hexadecimal string, each byte (8 bits) is
+        # represented by 2 hex chars. 256/8*2 = 64
+        self.assertEqual(len(v), 64)
+
+    def test_gather_summary_stats(self):
+        res = gather_summary_stats()
+        self.assertEqual(res["total_query_count"], 0)
+        self.assertEqual(res["default_database"], "sqlite")

--- a/explorer/tracker.py
+++ b/explorer/tracker.py
@@ -1,0 +1,115 @@
+# Anonymous usage stats
+# Opt-out by setting EXPLORER_ENABLE_ANONYMOUS_STATS = False in settings
+
+
+import time
+import requests
+import json
+import threading
+import hashlib
+from enum import Enum, auto
+from django.core.cache import cache
+from django.db import connection
+from django.db.models import Count
+from django.db.migrations.recorder import MigrationRecorder
+from django.conf import settings
+
+
+def _instance_identifier():
+    """
+    We need a way of identifying unique instances of explorer to track usage.
+    There isn"t an established approach I"m aware of, so have come up with
+    this. We take the timestamp of the first applied migration, and hash it
+    with the secret key.
+    """
+
+    try:
+        migration = MigrationRecorder.Migration.objects.all().order_by("applied").first()
+        ts = migration.applied.timestamp()
+        ts_bytes = str(ts).encode("utf-8")
+        s_bytes = settings.SECRET_KEY.encode("utf-8")
+        hashed_value = hashlib.sha256(ts_bytes + s_bytes).hexdigest()
+
+        return hashed_value
+    except Exception as e:
+        return "unknown: %s" % e
+
+
+def instance_identifier():
+    key = "explorer_instance_identifier"
+    r = cache.get(key)
+    if not r:
+        r = _instance_identifier()
+        cache.set(key, r, 60 * 60 * 24)
+    return r
+
+
+class SelfNamedEnum(Enum):
+
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return name
+
+
+class StatNames(SelfNamedEnum):
+
+    QUERY_RUN = auto()
+    QUERY_STREAM = auto()
+    STARTUP_STATS = auto()
+
+
+class Stat:
+
+    def __init__(self, name: StatNames, value):
+        self.instanceId = instance_identifier()
+        self.time = time.time()
+        self.value = value
+        self.name = name.value
+
+    def track(self):
+        from explorer import app_settings
+        if app_settings.EXPLORER_ENABLE_ANONYMOUS_STATS:
+            data = json.dumps(self.__dict__)
+            thread = threading.Thread(target=_send, args=(data,))
+            thread.start()
+
+
+def _send(data):
+    from explorer import app_settings
+    requests.post(app_settings.EXPLORER_COLLECT_ENDPOINT_URL,
+                  data=data,
+                  headers={"Content-Type": "application/json"})
+
+
+def gather_summary_stats():
+
+    from explorer import app_settings
+    from explorer.models import Query, QueryLog
+
+    try:
+        ql_stats = QueryLog.objects.aggregate(
+            total_count=Count("*"),
+            unique_run_by_user_count=Count("run_by_user_id", distinct=True)
+        )
+
+        q_stats = Query.objects.aggregate(
+            total_count=Count("*"),
+            unique_connection_count=Count("connection", distinct=True)
+        )
+
+        install_date = MigrationRecorder.Migration.objects.all().order_by("applied").first().applied.timestamp()
+
+        return {
+            "total_log_count": ql_stats["total_count"],
+            "unique_run_by_user_count": ql_stats["unique_run_by_user_count"],
+            "total_query_count": q_stats["total_count"],
+            "unique_connection_count": q_stats["unique_connection_count"],
+            "default_database": connection.vendor,
+            "django_install_date": install_date,
+            "debug": settings.DEBUG,
+            "tasks_enabled": app_settings.ENABLE_TASKS,
+            "unsafe_rendering": app_settings.UNSAFE_RENDERING,
+            "transform_count": len(app_settings.EXPLORER_TRANSFORMS)
+        }
+    except Exception as e:
+        return {"error": "error gathering stats: %s" % e}

--- a/explorer/views/stream.py
+++ b/explorer/views/stream.py
@@ -4,6 +4,7 @@ from django.views import View
 from explorer.models import Query
 from explorer.views.auth import PermissionRequiredMixin
 from explorer.views.export import _export
+from explorer.tracker import Stat, StatNames
 
 
 class StreamQueryView(PermissionRequiredMixin, View):
@@ -12,4 +13,7 @@ class StreamQueryView(PermissionRequiredMixin, View):
 
     def get(self, request, query_id, *args, **kwargs):
         query = get_object_or_404(Query, pk=query_id)
+        Stat(StatNames.QUERY_STREAM, {
+            "fmt": request.GET.get("format", "csv"),
+        }).track()
         return _export(request, query, download=False)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/chrisclark/django-sql-explorer/issues"
   },
-  "homepage": "https://github.com/chrisclark/django-sql-explorer#readme",
+  "homepage": "https://www.sqlexplorer.io",
   "dependencies": {
     "@codemirror/lang-sql": "^6.5.4",
     "@codemirror/language-data": "^6.3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 sqlparse>=0.4.0
 coverage
 factory-boy>=3.1.0
+requests~=2.31.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,9 @@ omit =
     explorer/migrations/*,
     explorer/tests/*,
     test_project/*,
+    */setup.py
+    */manage.py
+    test_project/*
 source =
 	explorer
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
                  " view, and export the results."),
     license="MIT",
     keywords="django sql explorer reports reporting csv database query",
-    url="https://github.com/chrisclark/django-sql-explorer",
+    url="https://www.sqlexplorer.io",
     project_urls={
       "Changes": "https://django-sql-explorer.readthedocs.io/en/latest/history.html",
       "Documentation": "https://django-sql-explorer.readthedocs.io/en/latest/",
@@ -76,6 +76,7 @@ setup(
     install_requires=[
         "Django>=3.2",
         "sqlparse>=0.4.0",
+        "requests>=2.2",
     ],
     extras_require={
         "charts": [

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -97,8 +97,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
-CELERY_TASK_ALWAYS_EAGER = True
-
 # added to help debug tasks
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
@@ -110,6 +108,10 @@ EXPLORER_TRANSFORMS = (
 )
 
 EXPLORER_USER_QUERY_VIEWS = {}
-# variable set in github action - assumed to be string
-EXPLORER_TASKS_ENABLED = os.environ.get("ENABLE_TASKS") == "yes"
+
+# Tasks disabled by default, but if you have celery installed
+# make sure the broker URL is set correctly
+EXPLORER_TASKS_ENABLED = False
+CELERY_BROKER_URL = 'redis://localhost:6379/0'
+
 EXPLORER_S3_BUCKET = "thisismybucket.therearemanylikeit.butthisoneismine"

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     optional: -r requirements/optional.txt
 commands =
     {envpython} --version
-    {env:COMMAND:coverage} run manage.py test
+    {env:COMMAND:coverage} run manage.py test --settings=tests.settings --noinput
 ignore_outcome =
     djmain: True
 ignore_errors =


### PR DESCRIPTION
Gathers a variety of usage metrics (largely at application start-up) and sends to a collection endpoint.

Some of the more interesting bits of this are:
- Generating a stable, but unique, ID per 'install'. See explorer.tracker._instance_identifier()
- Running stat collection at app start time. Strangely, Django doesn't have a good way to do this. See explorer.apps.track_summary_stats()
- The HTTP requests that are sent to the collection endpoint are 'fire and forget' via a thread.
- New app setting - EXPLORER_ENABLE_ANONYMOUS_STATS - that can be set to False to disable data collection

Other changes:
- Improved documentation (dev instructions, testing instructions, celery setup)
- Factored out a new tests.settings file so that test_project/settings.py is not overloaded to both serve as a good demo of the app AND supply all test values (updated tox accordingly)