### PR TITLE
Automatically fix problems with SQL assistant

### DIFF
--- a/explorer/assistant/tests.py
+++ b/explorer/assistant/tests.py
@@ -88,3 +88,22 @@ class TestPromptContext(TestCase):
             ("snapshot", "BooleanField"),
             ("connection", "CharField")])]
         self.assertEqual(ret, expected)
+
+
+class TestAssistantUtils(TestCase):
+
+    def test_sample_rows_from_tables(self):
+        from explorer.assistant.utils import sample_rows_from_tables
+        SimpleQueryFactory(title="First Query")
+        SimpleQueryFactory(title="Second Query")
+        ret = sample_rows_from_tables(CONN, ["explorer_query"])
+        print(ret)
+        self.assertTrue("First Query" in ret)
+        self.assertTrue("Second Query" in ret)
+
+    def test_sample_rows_from_tables_no_tables(self):
+        from explorer.assistant.utils import sample_rows_from_tables
+        SimpleQueryFactory(title="First Query")
+        SimpleQueryFactory(title="Second Query")
+        ret = sample_rows_from_tables(CONN, [])
+        self.assertEqual(ret, "")

--- a/explorer/assistant/utils.py
+++ b/explorer/assistant/utils.py
@@ -44,7 +44,7 @@ def tables_from_schema_info(connection, table_names):
 
 
 def sample_rows_from_tables(connection, table_names):
-    ret = ''
+    ret = ""
     for table_name in table_names:
         ret = f"SAMPLE FROM TABLE {table_name}:\n"
         ret = ret + format_rows_from_table(

--- a/explorer/assistant/utils.py
+++ b/explorer/assistant/utils.py
@@ -44,7 +44,7 @@ def tables_from_schema_info(connection, table_names):
 
 
 def sample_rows_from_tables(connection, table_names):
-    ret = None
+    ret = ''
     for table_name in table_names:
         ret = f"SAMPLE FROM TABLE {table_name}:\n"
         ret = ret + format_rows_from_table(

--- a/explorer/assistant/views.py
+++ b/explorer/assistant/views.py
@@ -18,8 +18,12 @@ def run_assistant(request_data, user):
 
     user_prompt = ""
 
-    db_vendor = get_valid_connection(request_data["connection"]).vendor
+    db_vendor = get_valid_connection(request_data.get("connection")).vendor
     user_prompt += f"## Database Vendor / SQL Flavor is {db_vendor}\n\n"
+
+    db_error = request_data.get("db_error")
+    if db_error:
+        user_prompt += f"## Query Error ##\n\n{db_error}\n\n"
 
     sql = request_data.get("sql")
     if sql:

--- a/explorer/src/js/assistant.js
+++ b/explorer/src/js/assistant.js
@@ -7,14 +7,29 @@ import List from "list.js";
 
 const spinner = "<div class=\"spinner-border text-primary\" role=\"status\"><span class=\"visually-hidden\">Loading...</span></div>";
 
+function getErrorMessage() {
+    const errorElement = document.querySelector('.alert-danger.db-error');
+    return errorElement ? errorElement.textContent.trim() : null;
+}
+
 export function setUpAssistant(expand = false) {
 
-    if(expand) {
+    const error = getErrorMessage();
+
+    if(expand || error) {
         const myCollapseElement = document.getElementById('assistant_collapse');
         const bsCollapse = new bootstrap.Collapse(myCollapseElement, {
           toggle: false
         });
         bsCollapse.show();
+        if(error) {
+            const textarea = document.getElementById('id_assistant_input');
+            textarea.value = "Please help me fix the error(s) in this query.";
+            const newDiv = document.createElement('div');
+            newDiv.textContent = 'Error messages are automatically included in the prompt. Just hit "Ask Assistant" and all relevant context will be injected to the LLM request.';  // Add any text or HTML content
+            newDiv.className = 'text-secondary small';
+            textarea.parentNode.insertBefore(newDiv, textarea.nextSibling);
+        }
     }
 
     const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
@@ -89,7 +104,8 @@ export function setUpAssistant(expand = false) {
             sql: window.editor?.state.doc.toString() ?? null,
             connection: document.getElementById("id_connection")?.value ?? null,
             assistant_request: document.getElementById("id_assistant_input")?.value ?? null,
-            selected_tables: selectedTables
+            selected_tables: selectedTables,
+            db_error: getErrorMessage()
         };
 
         document.getElementById("response_block").style.display = "block";

--- a/explorer/templates/explorer/play.html
+++ b/explorer/templates/explorer/play.html
@@ -13,7 +13,7 @@
             </p>
             <form role="form" action="{% url 'explorer_playground' %}" method="post" id="editor" class="playground-form form-horizontal">{% csrf_token %}
                 {% if error %}
-                    <div class="alert alert-danger">{{ error|escape }}</div>
+                    <div class="alert alert-danger db-error">{{ error|escape }}</div>
                 {% endif %}
                 {{ form.non_field_errors }}
                 {% if form.connections|length > 1 and can_change %}

--- a/explorer/templates/explorer/query.html
+++ b/explorer/templates/explorer/query.html
@@ -29,7 +29,7 @@
                     <form action="{% url 'query_create' %}" method="post" id="editor">{% csrf_token %}
                 {% endif %}
                 {% if error %}
-                    <div class="alert alert-danger">{{ error|escape }}</div>
+                    <div class="alert alert-danger db-error">{{ error|escape }}</div>
                 {% endif %}
                 {{ form.non_field_errors }}
                 <div class="my-3 form-floating">


### PR DESCRIPTION
When a query returns errors, the Assistant is pre-populated with a prompt to fix the error, and the error is automatically embedded in the context.