### PR TITLE
export assistant models

### DIFF
--- a/explorer/assistant/__init__.py
+++ b/explorer/assistant/__init__.py
@@ -1,0 +1,1 @@
+from .models import PromptLog

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -9,7 +9,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from explorer import app_settings
-from explorer.assistant import models as assistant_models
+# import the models so that the migration tooling knows the assistant models are part of the explorer app
+from explorer.assistant import models as assistant_models  # noqa
 from explorer.telemetry import Stat, StatNames
 from explorer.utils import (
     extract_params, get_params_for_url, get_s3_bucket, get_valid_connection, passes_blacklist, s3_url,

--- a/explorer/models.py
+++ b/explorer/models.py
@@ -9,6 +9,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from explorer import app_settings
+from explorer.assistant import models as assistant_models
 from explorer.telemetry import Stat, StatNames
 from explorer.utils import (
     extract_params, get_params_for_url, get_s3_bucket, get_valid_connection, passes_blacklist, s3_url,


### PR DESCRIPTION
Fixes issue where `python manage.py makemigrations` expects PromptLog model to be deleted, as the explorer app doesn't include it in its `models.py` file.

Example of the issue when moving from 4.0.2 to 4.2.0:
```
python3 manage.py makemigrations --check
Migrations for 'explorer':
  /opt/venv/lib/python3.9/site-packages/explorer/migrations/0016_delete_promptlog.py
    - Delete model PromptLog
```

Issue [615](https://github.com/chrisclark/django-sql-explorer/issues/615) may be related.