### PR TITLE
Release 4.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/_build/
 .env
 tst
 tst2
+tmp2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ Change Log
 This document records all notable changes to `django-sql-explorer <https://github.com/chrisclark/django-sql-explorer>`_.
 This project adheres to `Semantic Versioning <https://semver.org/>`_.
 
-`vNext`_ (unreleased)
+`4.3.0`_ (2024-05-27)
 ===========================
 
 * Keyboard shortcut to show schema hints (cmd+S / ctrl+S -- note that is a capital
@@ -552,5 +552,7 @@ Initial Release
 .. _#610: https://github.com/chrisclark/django-sql-explorer/issues/610
 .. _#612: https://github.com/chrisclark/django-sql-explorer/issues/612
 .. _#616: https://github.com/chrisclark/django-sql-explorer/issues/616
+.. _#618: https://github.com/chrisclark/django-sql-explorer/issues/618
+.. _#619: https://github.com/chrisclark/django-sql-explorer/issues/619
 
 .. _furo: https://github.com/pradyunsg/furo

--- a/explorer/__init__.py
+++ b/explorer/__init__.py
@@ -1,6 +1,6 @@
 __version_info__ = {
     "major": 4,
-    "minor": 2,
+    "minor": 3,
     "patch": 0,
     "releaselevel": "final",
     "serial": 0


### PR DESCRIPTION
`4.3.0`_ (2024-05-27)
===========================

* Keyboard shortcut to show schema hints (cmd+S / ctrl+S -- note that is a capital
  "S" so the full kbd commands is cmd+shift+s)
* DB-managed LLM prompts (editable in django admin)
* Versioned .js bundles (for cache busting)
* Automatically populate assistant responses that contain code into the editor
* `#616`_: Update schema/assistant tables/autocomplete on connection drop-down change
* `#618`_: Import models so that migrations are properly understood by Django
* `#619`_: Get CSRF from DOM (instead of cookie) if CSRF_USE_SESSIONS is set